### PR TITLE
Automate GitHub Release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
 
     permissions:
       id-token: write
+      contents: write
 
     steps:
       - name: Check out code
@@ -25,3 +26,8 @@ jobs:
 
       - name: Publish package
         run: uv publish --trusted-publishing automatic
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
Adds a step to our existing PyPI publish workflow.

When a new version tag is pushed, this will now automatically create a corresponding GitHub Release and populate it with auto-generated release notes. This keeps the PyPI package and GitHub releases in sync without any manual steps.