### PR TITLE
logging: send warnings/errors to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.10] - 2025-07-04
+
+### Fixed
+
+- **Logging**: Error and warning messages are now directed to standard error (stderr) while informational output remains on standard output (stdout). This prevents error traces from being mixed with regular logs and enables reliable shell redirection like `2>errors.log`.
+
 ## [0.2.9] - 2025-07-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatbot-tracer"
-version = "0.2.9"
+version = "0.2.10"
 
 description = "A tool to model chatbots and create profiles to test them."
 authors = [

--- a/tracer/utils/logging_utils.py
+++ b/tracer/utils/logging_utils.py
@@ -10,6 +10,22 @@ LOGGER_NAME = "chatbot_explorer"
 VERBOSE_LEVEL_NUM = 15
 logging.addLevelName(VERBOSE_LEVEL_NUM, "VERBOSE")
 
+
+class BelowWarningFilter(logging.Filter):
+    """Filters log records to allow only those with levels below WARNING."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Determines if a record should be logged.
+
+        Args:
+            record (logging.LogRecord): The log record.
+
+        Returns:
+            bool: True if the record's level is below WARNING, False otherwise.
+        """
+        return record.levelno < logging.WARNING
+
+
 try:
     import colorama
 
@@ -132,11 +148,20 @@ def setup_logging(verbosity: int = 0) -> None:
     if logger.hasHandlers():
         logger.handlers.clear()
 
-    handler = logging.StreamHandler(sys.stdout)  # Log to standard output
     formatter = ConditionalFormatter()
-    handler.setFormatter(formatter)
 
-    logger.addHandler(handler)
+    # Handler for INFO, VERBOSE, DEBUG messages to stdout
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.addFilter(BelowWarningFilter())
+    stdout_handler.setFormatter(formatter)
+
+    # Handler for WARNING, ERROR, CRITICAL messages to stderr
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.WARNING)
+    stderr_handler.setFormatter(formatter)
+
+    logger.addHandler(stdout_handler)
+    logger.addHandler(stderr_handler)
 
     # Prevent messages from propagating to the root logger
     # This is important to avoid double logging if root has default handlers


### PR DESCRIPTION
This update splits the log outputs:

* INFO / VERBOSE / DEBUG to stdout  
* WARNING / ERROR        to stderr

That keeps error traces out of normal output and lets us redirect them with `2>err.log`.

Steps to check
1. Run `python -m tracer.main 1>out.log 2>err.log`
2. Confirm that out.log has routine messages and err.log has warnings/errors only.

No other functional changes.